### PR TITLE
Update sanity_checks.yml

### DIFF
--- a/tasks/sanity_checks.yml
+++ b/tasks/sanity_checks.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - ansible_distribution in ["CentOS", "RedHat"]
-      - ansible_distribution_version | version_compare('7.4', '>=')
+      - ansible_distribution_version is version('7.4', '>=')
 
 - name: Sanity check of docker_storage_driver variable
   assert:


### PR DESCRIPTION
Ansible 2.9 (released Oct 31) removed the 'version_compare' filter (ref [ansible/issues/64174](http://guishunda.com/github_/ansible/ansible/issues/64174))

As such, the following line from configure.yml:
 ansible_distribution_version|version_compare(('7.4', '>=') 
Is throwing the following error:
"AnsibleError: template error while templating string: no filter named 'version_compare'"